### PR TITLE
Update model checkpoint directory path

### DIFF
--- a/config/main.yaml
+++ b/config/main.yaml
@@ -7,7 +7,10 @@ fit:
     num_nodes: 1
     precision: null
     logger: WandbLogger
-    callbacks: null
+    callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: ./models/
     fast_dev_run: false
     max_epochs: 1
     min_epochs: null

--- a/config/vertex.yaml
+++ b/config/vertex.yaml
@@ -1,0 +1,8 @@
+fit:
+  trainer:
+    callbacks:
+      - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+        init_args:
+          dirpath: /gcs/models_mlops/
+  data:
+    data_dir: /gcs/dataset-bucket-2/data


### PR DESCRIPTION
This pull request updates the model checkpoint directory path to `/gcs/models_mlops/` and the data directory path to `/gcs/dataset-bucket-2/data`. This ensures that the model checkpoints are saved in the correct location and the data is loaded from the correct directory.